### PR TITLE
feat: move map to workout location on sidebar click

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,6 +11,8 @@ const inputElevation = document.querySelector('.form__input--elevation');
 class Workout {
   date = new Date();
   id = (Date.now() + '').slice(-10);
+  clicks = 0;
+
   constructor(coords, distance, duration) {
     // this.date=...
     // this.id=...
@@ -25,6 +27,10 @@ class Workout {
     this.description = `${this.type[0].toUpperCase()}${this.type.slice(1)} on ${
       months[this.date.getMonth()]
     } ${this.date.getDate()}`;
+  }
+
+  click() {
+    this.clicks++;
   }
 }
 
@@ -62,21 +68,23 @@ class Cycling extends Workout {
   }
 }
 
-// const run1 = new Running([39, -12], 5.2, 24, 178);
-// const cycling1 = new Cycling([39, -12], 27, 98, 523);
-// console.log(run1, cycling1);
+const run1 = new Running([39, -12], 5.2, 24, 178);
+const cycling1 = new Cycling([39, -12], 27, 98, 523);
+console.log(run1, cycling1);
 
 //////////////////////////////////////
 // APPLICATION ARCHITECTURE
 class App {
   #map;
+  #mapZoomLevel = 13;
   #mapEvent;
-  #workout = [];
+  #workouts = [];
   constructor() {
     this._getPosition();
     form.addEventListener('submit', this._newWorkout.bind(this));
     1;
     inputType.addEventListener('change', this._toggleElevationField);
+    containerWorkouts.addEventListener('click', this._moveToPopup.bind(this));
   }
 
   _getPosition() {
@@ -93,7 +101,7 @@ class App {
     const { latitude } = position.coords;
     const { longitude } = position.coords;
     const coords = [latitude, longitude];
-    this.#map = L.map('map').setView(coords, 13);
+    this.#map = L.map('map').setView(coords, this.#mapZoomLevel);
     // console.log(map);
 
     L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -171,7 +179,7 @@ class App {
       workout = new Cycling([lat, lng], distance, duration, elevation);
     }
     // Add new object to workout array
-    this.#workout.push(workout);
+    this.#workouts.push(workout);
     console.log(workout);
 
     // Render workout on map as marker
@@ -250,6 +258,23 @@ class App {
     }
 
     containerWorkouts.insertAdjacentHTML('beforeend', html);
+  }
+
+  _moveToPopup(e) {
+    const workoutEl = e.target.closest('.workout');
+    if (!workoutEl) return;
+    console.log(workout);
+    const workout = this.#workouts.find(
+      work => work.id === workoutEl.dataset.id
+    );
+
+    this.#map.setView(workout.coords, this.#mapZoomLevel, {
+      animate: true,
+      pan: { duration: 1 },
+    });
+
+    // using that public interface
+    workout.click();
   }
 }
 


### PR DESCRIPTION
## 🗺️ 253. Move to Marker On Click

### ✨ What’s Implemented
- Added click listener on `.workouts` container using **event delegation**
- Used `.closest('.workout')` to safely get the clicked workout list item
- Extracted `data-id` from clicked workout element
- Found the corresponding workout in `#workouts` using `.find(...)`
- Used `this.#map.setView()` to pan to the workout’s coordinates
- Added smooth animation (`animate: true`, `duration: 1`)
- Introduced a simple public method `click()` in `Workout` class to increment a `.clicks` counter

### ✅ Code Snippet
```js
_moveToPopup(e) {
  const workoutEl = e.target.closest('.workout');
  if (!workoutEl) return;

  const workout = this.#workouts.find(
    work => work.id === workoutEl.dataset.id
  );

  this.#map.setView(workout.coords, this.#mapZoomLevel, {
    animate: true,
    pan: { duration: 1 },
  });

  // Public method example
  workout.click();
}
```

### 🧠 Notes
- `this._moveToPopup.bind(this)` ensures `this` points to the App instance
- Public method `click()` showcases class interaction from outside the class
- Using `data-id` in DOM helps connect UI to logic cleanly

---
