### PR TITLE
Persist workouts using localStorage

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,19 +68,23 @@ class Cycling extends Workout {
   }
 }
 
-const run1 = new Running([39, -12], 5.2, 24, 178);
-const cycling1 = new Cycling([39, -12], 27, 98, 523);
-console.log(run1, cycling1);
+// const run1 = new Running([39, -12], 5.2, 24, 178);
+// const cycling1 = new Cycling([39, -12], 27, 98, 523);
+// console.log(run1, cycling1);
 
 //////////////////////////////////////
 // APPLICATION ARCHITECTURE
 class App {
   #map;
-  #mapZoomLevel = 13;
+  #mapZoomLevel = 15;
   #mapEvent;
   #workouts = [];
   constructor() {
+    // Get user's positions
     this._getPosition();
+    // Get data from local storage
+    this._getLocalStorage();
+    // Attach event handlers
     form.addEventListener('submit', this._newWorkout.bind(this));
     1;
     inputType.addEventListener('change', this._toggleElevationField);
@@ -111,6 +115,10 @@ class App {
 
     // Handling click on map
     this.#map.on('click', this._showForm.bind(this));
+
+    this.#workouts.forEach(work => {
+      this._renderWorkoutMarker(work);
+    });
   }
 
   _showForm(mapE) {
@@ -180,7 +188,6 @@ class App {
     }
     // Add new object to workout array
     this.#workouts.push(workout);
-    console.log(workout);
 
     // Render workout on map as marker
     this._renderWorkoutMarker(workout);
@@ -190,6 +197,9 @@ class App {
 
     // Hide form + clear input fields
     this._hideForm();
+
+    // Set local storage to all workouts
+    this._setLocalStorage();
   }
 
   _renderWorkoutMarker(workout) {
@@ -263,7 +273,6 @@ class App {
   _moveToPopup(e) {
     const workoutEl = e.target.closest('.workout');
     if (!workoutEl) return;
-    console.log(workout);
     const workout = this.#workouts.find(
       work => work.id === workoutEl.dataset.id
     );
@@ -274,7 +283,28 @@ class App {
     });
 
     // using that public interface
-    workout.click();
+    // workout.click();
+  }
+
+  _setLocalStorage() {
+    localStorage.setItem('workouts', JSON.stringify(this.#workouts));
+  }
+
+  _getLocalStorage() {
+    const data = JSON.parse(localStorage.getItem('workouts'));
+
+    if (!data) return;
+
+    this.#workouts = data;
+
+    this.#workouts.forEach(work => {
+      this._renderWorkout(work);
+    });
+  }
+
+  reset() {
+    localStorage.removeItem('workouts');
+    location.reload();
   }
 }
 


### PR DESCRIPTION
## 💾 254. Working with localStorage

### ✨ What’s Implemented
- Added `_setLocalStorage()` to store workouts as JSON in the browser
- Added `_getLocalStorage()` to retrieve stored workouts on app load
- Used `JSON.stringify()` and `JSON.parse()` to handle data transformation
- Ensured workouts are rendered **after** map is ready to avoid async issues
- Stored workouts persist across sessions and reloads
- Disabled `.click()` method usage on stored workouts due to prototype loss
- Introduced a `reset()` method for clearing all data from local storage and reloading the app

### ✅ Key Code Snippets

```js
// Save workouts
_setLocalStorage() {
  localStorage.setItem('workouts', JSON.stringify(this.#workouts));
}

// Load workouts
_getLocalStorage() {
  const data = JSON.parse(localStorage.getItem('workouts'));
  if (!data) return;
  this.#workouts = data;
  this.#workouts.forEach(work => this._renderWorkout(work));
}

// Delete and reload
reset() {
  localStorage.removeItem('workouts');
  location.reload();
}
```

### 🧠 Notes
- `workouts` from localStorage become plain objects, losing prototype methods like `.click()`
- Rendering markers must happen **after map is loaded**, inside `_loadMap()`
- Use `app.reset()` in console to clear all data and reload the app
